### PR TITLE
Transcluding HTTP links

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,15 @@ hercule.transcludeString("# Title\n\n:[abstract](abstract.md)", null, null, null
 Hercule extends the Markdown inline link syntax with a leading colon (`:`) to denote the link should transcluded.
 
 ```markdown
-This is an :[example link](example.md).
+This is an :[example link](example.md).  
+And this is an :[example link](https://raw.githubusercontent.com/jamesramsay/hercule/master/examples/example.md), too.
 ```
 
 Output from `hercule examples/basic.md`:
 
 ```
 This is an example transclusion.
+And this is an example transclusion, too.
 ```
 
 Extending the standard Markdown link syntax means that most other markdown parsers will treat them as normal links.

--- a/package.json
+++ b/package.json
@@ -42,12 +42,15 @@
   "dependencies": {
     "dashdash": "^1.7.0",
     "lodash": "^3.0.0",
-    "pegjs": "^0.8.0"
+    "pegjs": "^0.8.0",
+    "request": "^2.58.0",
+    "deasync": "^0.1.0"
   },
   "devDependencies": {
     "coffee-script": "^1.7.0",
     "mocha": "^2.2.5",
     "mocha-lcov-reporter": "^0.0.2",
+    "nock": "^2.7.0",
     "assert-diff": "^1.0.1",
     "blanket": "^1.1.7",
     "coveralls": "^2.11.2"

--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -3,6 +3,7 @@ blanket = require 'blanket' if process.env.COVERAGE
 path = require 'path'
 _ = require 'lodash'
 utils = require './utils'
+validUrlRegex = /(http|https):\/\/(\w+:{0,1}\w*)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%!\-\/]))?/
 
 #log = (message) -> return
 
@@ -36,7 +37,7 @@ transclude = (input, relativePath, parents, parentRefs, cb) ->
       #log "Expanding: #{link} -> #{match.value}"
       link = match.value
       linkType = match.type
-    else
+    else if !match? && !validUrlRegex.test(link)
       link = path.join relativePath, link
 
     if _.contains parents, link

--- a/test/utils.coffee
+++ b/test/utils.coffee
@@ -1,7 +1,7 @@
 require 'coffee-script/register'
 assert = require 'assert-diff'
 utils = require '../src/utils'
-
+nock = require 'nock'
 
 describe 'utils', ->
 
@@ -148,6 +148,16 @@ describe 'utils', ->
 
       content = utils.readFile inputFile
       assert.equal content, 'The quick brown fox jumps over the lazy dog.\n'
+
+      done()
+
+    it 'should read remote file if path is a valid URL', (done) ->
+      inputFile = 'http://www.google.com'
+      expectedContent = '{ "content": "" }'
+      file = nock(inputFile).get('/').reply(200, expectedContent)
+      content = utils.readFile inputFile
+
+      assert.equal content, expectedContent
 
       done()
 


### PR DESCRIPTION
This resolves #22. Some refactoring might be appropriate, but I had a hard time to figure out, which role `link.type` plays and if one could extend this for a cleaner http link support. 