### PR TITLE
Fix empty reference extension

### DIFF
--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -25,8 +25,8 @@ transclude = (input, relativePath, parents, parentRefs, logger, cb) ->
     if not matchingReferences[0]? and hrefType is "file"
       href = path.join relativePath, href
 
-    href = overridingReference?.href || href
-    hrefType = overridingReference?.hrefType || hrefType
+    href = overridingReference.href if overridingReference?
+    hrefType = overridingReference.hrefType if overridingReference?
 
     if _.contains parents, href
       logger "#{href} is in parents:\n#{JSON.stringify parents}"

--- a/test/fixtures/test-extend/activity.md
+++ b/test/fixtures/test-extend/activity.md
@@ -1,1 +1,1 @@
-jumps over the :[state](state) :[animal](animal)
+jumps :[this should be removed](empty)over the :[state](state) :[animal](animal)

--- a/test/fixtures/test-extend/fox.md
+++ b/test/fixtures/test-extend/fox.md
@@ -1,1 +1,1 @@
-The quick brown fox :[activity](activity.md animal:canine.md state:disinterest.md).
+The quick brown fox :[activity](activity.md animal:canine.md state:disinterest.md empty:).


### PR DESCRIPTION
Fixed issue where empty extends (`:[empty extend link](file.md extend:"")` and :[empty extend link](file.md extend:)) would fail.