### PR TITLE
Don't hang if a transclusion couldn't be found

### DIFF
--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -45,7 +45,7 @@ transclude = (input, relativePath, parents, parentRefs, logger, cb) ->
             .replace /\n$/, ""
 
           input = input.replace "#{placeholder}", output
-          return done()
+        return done()
   , ->
     return cb input
 

--- a/test/fixtures/test-default/missing-link.md
+++ b/test/fixtures/test-default/missing-link.md
@@ -1,0 +1,1 @@
+Jackdaws love my :[test link](non-existend-file.md) sphinx of quartz.

--- a/test/hercule.coffee
+++ b/test/hercule.coffee
@@ -87,6 +87,15 @@ describe 'hercule', ->
         assert.equal output, 'Jackdaws love my imagined sphinx of quartz.\n'
         done()
 
+    it 'should transclude strings with invalid links without hanging', (done) ->
+      file = __dirname + "/fixtures/test-default/missing-link.md"
+      input = (fs.readFileSync file).toString()
+      dir = path.dirname file
+
+      hercule.transcludeString input, null, {relativePath: dir}, (output) ->
+        assert.equal output, 'Jackdaws love my :[test link](non-existend-file.md) sphinx of quartz.\n'
+        done()
+
 
   describe 'transcludeFile', ->
 


### PR DESCRIPTION
The current code fails to call `done()` if a transcluded file couldn't be found. It should simply fail to make the replacement and continue processing.