### PR TITLE
Escape dollar signs in the output

### DIFF
--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -43,6 +43,7 @@ transclude = (input, relativePath, parents, parentRefs, logger, cb) ->
           output = output
             .replace /\n/g, "\n#{whitespace}"
             .replace /\n$/, ""
+            .replace /\$/, "$$$$"
 
           input = input.replace "#{placeholder}", output
         return done()

--- a/test/fixtures/escaped-dollars/_expect.md
+++ b/test/fixtures/escaped-dollars/_expect.md
@@ -1,0 +1,3 @@
+Some prefix content.
+
+A regex: `^pattern$`

--- a/test/fixtures/escaped-dollars/foo.md
+++ b/test/fixtures/escaped-dollars/foo.md
@@ -1,0 +1,1 @@
+A regex: `^pattern$`

--- a/test/fixtures/escaped-dollars/index.md
+++ b/test/fixtures/escaped-dollars/index.md
@@ -1,0 +1,3 @@
+Some prefix content.
+
+:[example](foo.md)


### PR DESCRIPTION
The string replace function [supports patterns in the replacement string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter), triggered by a dollar sign ($). When a transcluded file includes one of these patterns (such as in a regular expression) it messes up the generated output. This pull request fixes the issue by escaping all dollar signs in the output before doing the replacement.

To see an example of the messed-up output, run the included unit test without the accompanying fix in hercule.coffee.