### PR TITLE
Fixed handling of special characters

### DIFF
--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -44,7 +44,7 @@ transclude = (input, relativePath, parents, parentRefs, logger, cb) ->
             .replace /\n/g, "\n#{whitespace}"
             .replace /\n$/, ""
 
-          input = input.replace "#{placeholder}", output
+          input = input.replace "#{placeholder}", () -> output
         return done()
   , ->
     return cb input

--- a/test/fixtures/special-characters/_expect.md
+++ b/test/fixtures/special-characters/_expect.md
@@ -1,0 +1,5 @@
+A regular expression is a pattern that the regular expression engine attempts to match in input text.
+
+Example: `^pattern$`
+
+Markdown quoted ('$') vs escaped (`$`)

--- a/test/fixtures/special-characters/bar.md
+++ b/test/fixtures/special-characters/bar.md
@@ -1,0 +1,1 @@
+Markdown quoted ('$') vs escaped (`$`)

--- a/test/fixtures/special-characters/foo.md
+++ b/test/fixtures/special-characters/foo.md
@@ -1,0 +1,1 @@
+Example: `^pattern$`

--- a/test/fixtures/special-characters/index.md
+++ b/test/fixtures/special-characters/index.md
@@ -1,0 +1,5 @@
+A regular expression is a pattern that the regular expression engine attempts to match in input text.
+
+:[Example](foo.md)
+
+:[Alt example](bar.md)


### PR DESCRIPTION
- str.replace supports special patterns which cannot be guaranteed to
not to occur in input files.

- Changed use of replace to use a function to bypass special behaviour

Thanks to @dgileadi for the bug report #64 :rocket:  