### PR TITLE
Don't preserve resolved references for siblings

### DIFF
--- a/src/hercule.coffee
+++ b/src/hercule.coffee
@@ -39,7 +39,7 @@ transclude = (input, relativePath, parents, parentRefs, logger, cb) ->
 
     parents.push href
     dir = path.dirname href
-    references = _.merge parentRefs, references
+    references = _.merge [], parentRefs, references
 
     utils.inflate href, hrefType, (content) ->
       logger "Transcluding: #{href} (#{hrefType}) into #{parents[-1..][0]}"

--- a/test/fixtures/reset-references/_expect.md
+++ b/test/fixtures/reset-references/_expect.md
@@ -1,0 +1,6 @@
+## Properties
+
+- id: 1 (number, required)
+- name: Cucumber (string, required)
+- description: Essential for tzatziki (string, required)
+- notes: Watch the temperature (string, optional)

--- a/test/fixtures/reset-references/index.md
+++ b/test/fixtures/reset-references/index.md
@@ -1,0 +1,6 @@
+## Properties
+
+- id: 1 (number, required)
+- name: Cucumber (string, required)
+- description: Essential for tzatziki (string, :[required](required.md required:"required"))
+- notes: Watch the temperature (string, :[optional](required.md))

--- a/test/fixtures/reset-references/required.md
+++ b/test/fixtures/reset-references/required.md
@@ -1,0 +1,1 @@
+:[is required](required || "optional")


### PR DESCRIPTION
As the test shows, if multiple includes resolve to the same file and if one of the includes has a reference, that reference will be propagated to all the subsequent includes, even to those that don't specify the reference.

The culprit is the fact that loadash's `merge` function modifies its first argument rather than returning a brand new clone. The solution is to merge everything into an empty array, to avoid accidentally modifying `parentRefs`.

Another possible solution might be the code

    references = _.merge references, parentRefs

But that would override any same-named references in `references` with those in `parentRefs`, which would probably be undesirable.