### PR TITLE
Enable Babel ES2015 transcompiler

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "compile": {
+      "presets": ["es2015"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "integration-test": "./test/modules/bin/bats test/bats",
     "coverage": "./node_modules/.bin/nyc report --reporter=html && open coverage/index.html",
     "coveralls": "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls",
-    "compile": "mkdir -p lib && ./node_modules/.bin/pegjs src/transclude.pegjs lib/transclude-parser.js",
+    "compile": "BABEL_ENV=compile ./node_modules/.bin/babel src --out-dir lib && ./node_modules/.bin/pegjs src/transclude.pegjs lib/transclude-parser.js",
     "install-bats": "./scripts/install-bats"
   },
   "config": {
@@ -57,6 +57,8 @@
   "devDependencies": {
     "assert-diff": "^1.0.1",
     "ava": "^0.5.0",
+    "babel-cli": "^6.2.0",
+    "babel-preset-es2015": "^6.1.18",
     "blanket": "^1.1.9",
     "coveralls": "^2.11.4",
     "nock": "^3.0.0",


### PR DESCRIPTION
- Use `compile` environment to avoid `.babelrc` messing with ava's own version of babel.