### PR TITLE
Strip trailing new line at EOF for nested transcludes

### DIFF
--- a/src/trim-stream.js
+++ b/src/trim-stream.js
@@ -1,0 +1,36 @@
+import through2 from 'through2';
+
+/**
+* Trims EOF new line
+*
+* Input stream: (string)
+*
+* Output stream: (string)
+*/
+
+module.exports = function TrimStream() {
+  let inputBuffer = '';
+
+  function transform(chunk, encoding, cb) {
+    if (chunk) inputBuffer += chunk.toString('utf8');
+
+    this.push(inputBuffer.slice(0, -1));
+    inputBuffer = inputBuffer.slice(-1);
+
+    cb();
+  }
+
+
+  function flush(cb) {
+    // Empty internal buffer and signal the end of the output stream.
+    if (inputBuffer !== '') {
+      inputBuffer = inputBuffer.replace(/\n$/, '');
+      this.push(inputBuffer);
+    }
+
+    this.push(null);
+    cb();
+  }
+
+  return through2.obj(transform, flush);
+};

--- a/test/trim-stream.js
+++ b/test/trim-stream.js
@@ -1,0 +1,85 @@
+import test from 'ava';
+import TrimStream from '../lib/trim-stream';
+
+
+test('should handle no input', (t) => {
+  const testStream = new TrimStream();
+
+  testStream.on('readable', function read() {
+    if (this.read() !== null) t.fail();
+  });
+
+  testStream.on('end', function end() {
+    t.pass();
+    t.end();
+  });
+
+  testStream.end();
+});
+
+
+test('should not modify input without trailing new line', (t) => {
+  const input = 'The quick brown fox jumps over the lazy dog.';
+  const testStream = new TrimStream();
+  let output = '';
+
+  testStream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      output += chunk;
+    }
+  });
+
+  testStream.on('end', function end() {
+    t.same(output, input);
+    t.end();
+  });
+
+  testStream.write(input);
+  testStream.end();
+});
+
+
+test('should not modify input with internal new lines', (t) => {
+  const input = 'The quick brown\nfox jumps\nover the lazy dog.';
+  const testStream = new TrimStream();
+  let output = '';
+
+  testStream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      output += chunk;
+    }
+  });
+
+  testStream.on('end', function end() {
+    t.same(output, input);
+    t.end();
+  });
+
+  testStream.write(input);
+  testStream.end();
+});
+
+
+test('should only trim trailing new line', (t) => {
+  const input = 'The quick brown\nfox jumps\nover the lazy dog.\n\n';
+  const expect = 'The quick brown\nfox jumps\nover the lazy dog.\n';
+  const testStream = new TrimStream();
+  let output = '';
+
+  testStream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      output += chunk;
+    }
+  });
+
+  testStream.on('end', function end() {
+    t.same(output, expect);
+    t.end();
+  });
+
+  testStream.write(input);
+  testStream.end();
+});


### PR DESCRIPTION
- Transcluding a file in line without striping the trailing new line
results in the output having extra new lines which are not desired.