### PR TITLE
fix(resolve-stream): handling of parentRefs

### DIFF
--- a/test/resolve-stream.js
+++ b/test/resolve-stream.js
@@ -89,8 +89,8 @@ test.cb('should parse input with overriding link', (t) => {
       references: [
         {
           placeholder: 'animal',
-          href: 'fox.md',
-          hrefType: 'file'
+          href: 'wolf.md',
+          hrefType: 'file',
         },
         {
           placeholder: 'food',
@@ -99,6 +99,18 @@ test.cb('should parse input with overriding link', (t) => {
         },
       ],
     },
+    parentRefs: [
+      {
+        placeholder: 'animal',
+        href: 'fox.md',
+        hrefType: 'file',
+      },
+      {
+        placeholder: 'food',
+        href: 'cheese.md',
+        hrefType: 'file',
+      },
+    ],
   };
   const expected = {
     href: 'fox.md',


### PR DESCRIPTION
Only references from parent links should influence how the link is resolved,
not references within the link that is being resolved.