### PR TITLE
chore(coverage): prevent running tests twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "npm run compile && npm run unit-test && npm run integration-test",
     "posttest": "npm run lint",
-    "unit-test": "./node_modules/.bin/nyc ./node_modules/.bin/ava",
+    "unit-test": "./node_modules/.bin/nyc --reporter=json ./node_modules/.bin/ava",
     "integration-test": "./test/modules/bin/bats test/bats",
     "coverage": "./scripts/coverage && ./node_modules/.bin/istanbul report --reporter=html && open coverage/index.html",
     "codecov": "./scripts/coverage && cat coverage/coverage.json | ./node_modules/.bin/codecov",

--- a/scripts/coverage
+++ b/scripts/coverage
@@ -5,10 +5,10 @@ set -e
 # been applied.
 
 # Clear previous coverage.
-rm -rf coverage
+#rm -rf coverage
 
 # Generate test coverage based on however `npm test` performs the tests.
-./node_modules/.bin/nyc --reporter=json ./node_modules/.bin/ava
+#./node_modules/.bin/nyc --reporter=json ./node_modules/.bin/ava
 
 # Move generated JSON file so it can be remapped and won't confuse Istanbul
 # later.


### PR DESCRIPTION
Tests were being run twice. Once to determine test pass/fail, and again for calculating coverage. The results of the first test are sufficient to calculate coverage.