### PR TITLE
fix(peg-stream): catch pegjs parsing errors preventing program crash

### DIFF
--- a/src/inflate-stream.js
+++ b/src/inflate-stream.js
@@ -39,7 +39,7 @@ module.exports = function InflateStream(options) {
     const self = this;
     const tokenizer = new RegexStream(linkRegExp, {
       match: {
-        link: `${LINK_GROUP}`,
+        match: `${LINK_GROUP}`,
         indent: (match) => {
           return [chunk.indent, _.get(match, `${WHITESPACE_GROUP}`)].join('');
         },

--- a/src/peg-stream.js
+++ b/src/peg-stream.js
@@ -14,7 +14,7 @@ Input and output properties can be altered by providing options
 */
 
 const defaultOptions = {
-  expression: 'link',
+  expression: 'match',
   parsed: 'link',
 };
 
@@ -31,9 +31,17 @@ module.exports = function PegStream(grammar, options) {
       return cb();
     }
 
-    parsed = grammar.parse(expression);
+    try {
+      parsed = {
+        [opt.parsed]: grammar.parse(expression),
+      };
+    } catch (err) {
+      // TODO: store the error to chunk
+      // console.log(JSON.stringify({err}));
+      parsed = null;
+    }
 
-    this.push(_.assign({}, chunk, {[opt.parsed]: parsed}));
+    this.push(_.assign({}, chunk, parsed));
     return cb();
   }
 

--- a/src/transclude-stream.js
+++ b/src/transclude-stream.js
@@ -33,7 +33,7 @@ module.exports = function Transcluder(options) {
 
   const tokenizer = new RegexStream(linkRegExp, {
     match: {
-      link: `${LINK_GROUP}`,
+      match: `${LINK_GROUP}`,
       indent: `${WHITESPACE_GROUP}`,
     },
     leaveBehind: `${WHITESPACE_GROUP}`,

--- a/test/fixtures/syntax-error/_expect.md
+++ b/test/fixtures/syntax-error/_expect.md
@@ -1,0 +1,1 @@
+The quick brown :[](animal.md foo:bar:"exception!") jumps over the lazy dog.

--- a/test/fixtures/syntax-error/index.md
+++ b/test/fixtures/syntax-error/index.md
@@ -1,0 +1,1 @@
+The quick brown :[](animal.md foo:bar:"exception!") jumps over the lazy dog.

--- a/test/peg-stream.js
+++ b/test/peg-stream.js
@@ -66,3 +66,26 @@ test.cb('should parse input with expression', (t) => {
   testStream.write(input);
   testStream.end();
 });
+
+
+test.cb('should handle parse error', (t) => {
+  const input = {
+    chunk: 'The quick brown :[](animal.md foo:bar:"exception!") jumps over the lazy dog./n',
+    link: 'animal.md foo:bar:"exception!"',
+  };
+  const testStream = new PegStream(grammar);
+
+  testStream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      t.ok(chunk.link);
+    }
+  });
+
+  testStream.on('end', function end() {
+    t.end();
+  });
+
+  testStream.write(input);
+  testStream.end();
+});


### PR DESCRIPTION
If the transclusion link is malformed, pegjs will be unable to parse the link an will throw an exception.

This should be handled by stopping the link from being processed further, and output should contain unmodified link.

Closes #107