### PR TITLE
Support a custom logger for errors

### DIFF
--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -40,34 +40,34 @@ parse = (link) ->
 
 
 # Read file to string
-readFile = (filename) ->
+readFile = (filename, logger) ->
   try
     content = (fs.readFileSync filename).toString()
     return content
   catch err
     if err.code is 'ENOENT'
-      console.error "Error: File (#{filename}) not found."
+      logger.error "Error: File (#{filename}) not found."
   return null
 
 
 # Read URI contents to string
-readUri = (uri, cb) ->
+readUri = (uri, logger, cb) ->
   request uri, (err, res, body) ->
     if (err) or not (res.statusCode is 200)
-      console.error "Error: Remote file (#{uri}) could not be retrieved."
+      logger.error "Error: Remote file (#{uri}) could not be retrieved."
       return cb null
     return cb body
 
 
-inflate = (href, hrefType, cb) ->
+inflate = (href, hrefType, logger, cb) ->
   switch hrefType
     when "string"
       return cb href
     when "file"
-      content = readFile href
+      content = readFile href, logger
       return cb content
     when "http"
-      readUri href, (content) ->
+      readUri href, logger, (content) ->
         return cb content
     else
       return cb ""

--- a/test/inflate.js
+++ b/test/inflate.js
@@ -2,9 +2,15 @@ import test  from 'ava';
 import utils from '../lib/utils';
 import nock  from 'nock';
 
+
+var logger = {
+  error: function() {}
+}
+
+
 test.cb('should return strings', (t) => {
   t.plan(1);
-  utils.inflate('dog', 'string', function(output) {
+  utils.inflate('dog', 'string', logger, function(output) {
     t.same(output, 'dog');
     t.end();
   });
@@ -14,7 +20,7 @@ test.cb('should return strings', (t) => {
 test.cb('should return contents of local files', (t) => {
   t.plan(1);
   let file = __dirname + "/fixtures/basic/index.md";
-  utils.inflate(file, 'file', function(output) {
+  utils.inflate(file, 'file', logger, function(output) {
     t.same(output, 'Jackdaws love my :[size link](size.md) sphinx of quartz.\n');
     t.end();
   });
@@ -29,7 +35,7 @@ test.cb('should return contents of http files', (t) => {
 
   let mock = nock(url).get(file).reply(200, fox);
 
-  utils.inflate(`${url}${file}`, 'http', function(output) {
+  utils.inflate(`${url}${file}`, 'http', logger, function(output) {
     t.same(output, 'The quick brown fox jumps over the lazy dog.\n');
     t.end();
   });
@@ -38,7 +44,7 @@ test.cb('should return contents of http files', (t) => {
 
 test.cb('should return empty string for unsupported types', (t) => {
   t.plan(1);
-  utils.inflate('', 'foo', function(output) {
+  utils.inflate('', 'foo', logger, function(output) {
     t.same(output, '');
     t.end();
   });

--- a/test/read.js
+++ b/test/read.js
@@ -3,48 +3,62 @@ import utils from '../lib/utils';
 import nock  from 'nock';
 
 
+test.beforeEach(t => {
+  t.context.logOutput = []
+  t.context.logger = {
+    error: function(message) {
+      t.context.logOutput.push(message);
+    }
+  }
+});
+
+
 test('readFile should return null for missing files', (t) => {
-  t.plan(1);
+  t.plan(2);
   let inputFile = __dirname + "/fixtures/i-dont-exist.md";
 
-  let content = utils.readFile('missing.md');
+  let content = utils.readFile('missing.md', t.context.logger);
   t.same(content, null);
+  t.same(t.context.logOutput.length, 1);
 });
 
 
 test('readFile should read files which exist', (t) => {
-  t.plan(1);
+  t.plan(2);
   let inputFile = __dirname + "/fixtures/basic/index.md";
 
-  let content = utils.readFile(inputFile);
+  let content = utils.readFile(inputFile, t.context.logger);
   t.same(content, 'Jackdaws love my :[size link](size.md) sphinx of quartz.\n');
+  t.same(t.context.logOutput.length, 0);
 });
 
 
 test.cb('readUri should return null for files not found (404)', (t) => {
-  t.plan(1);
+  t.plan(2);
   let url  = "http://github.com";
   let file = "/dog.md";
 
   let mock = nock(url).get(file).reply(404);
 
-  utils.readUri(`${url}${file}`, function(content) {
+  utils.readUri(`${url}${file}`, t.context.logger, function(content) {
     t.same(content, null);
+    t.same(t.context.logOutput.length, 1);
     t.end();
   });
 });
 
 
 test.cb('readUri should read http files which exist', (t) => {
-  t.plan(1);
+  t.plan(2);
   let url  = "http://github.com";
   let file = "/fox.md";
   let fox  = "The quick brown fox jumps over the lazy dog.\n";
 
   let mock = nock(url).get(file).reply(200, fox);
 
-  utils.readUri(`${url}${file}`, function(content) {
+  utils.readUri(`${url}${file}`, t.context.logger, function(content) {
     t.same(content, 'The quick brown fox jumps over the lazy dog.\n');
+    t.same(t.context.logOutput.length, 0);
     t.end();
   });
 });

--- a/test/transcludeString.js
+++ b/test/transcludeString.js
@@ -27,13 +27,32 @@ test('should require a string', (t) => {
 });
 
 
-test.cb('should allow a custom logger to be provided', (t) => {
+test.cb('should allow a custom logger function to be provided', (t) => {
   t.plan(2);
   let input = 'Jackdaws love my big sphinx of quartz.\n'
   let logOutput = []
 
   let logger = function(message) {
     logOutput.push(message);
+  }
+
+  hercule.transcludeString(input, logger, function(output) {
+    t.same(output, 'Jackdaws love my big sphinx of quartz.\n');
+    t.same(logOutput.length, 2);
+    t.end();
+  });
+});
+
+
+test.cb('should allow a custom logger object to be provided', (t) => {
+  t.plan(2);
+  let input = 'Jackdaws love my big sphinx of quartz.\n'
+  let logOutput = []
+
+  let logger = {
+    debug: function(message) {
+      logOutput.push(message);
+    }
   }
 
   hercule.transcludeString(input, logger, function(output) {


### PR DESCRIPTION
The current code offers the ability to provide a custom logger for debug messages, but offers no customization for error logging (which can happen due to file-not-found errors or HTTP errors). This pull request adds support for making the logger argument be an object with `debug` and `error` functions. If no logger argument is provided or if the logger argument is a function then the current behavior is used.