### PR TITLE
chore(npm): 2.x.x-alpha should be on the `next` dist-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
     "nock": "^3.0.0",
     "nyc": "^5.0.0",
     "pegjs": "^0.9.0"
+  },
+  "publishConfig": {
+    "tag": "next"
   }
 }


### PR DESCRIPTION
2.x.x releases should be on the `next` dist-tag to prevent new users accidentally ending up on 2.x release.