### PR TITLE
fix(indent): leave behind indentation assumed no failures

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -16,17 +16,18 @@ export const LINK_REGEXP = new RegExp(/(^[\t ]*)?(\:\[.*?\]\((.*?)\))/gm);
 export const WHITESPACE_GROUP = 1;
 export const PLACEHOLDER_GROUP = 2;
 export const LINK_GROUP = 3;
+export const LINK_MATCH = {
+  link: function getLink(match) {
+    return {
+      href: _.get(match, `[${LINK_GROUP}]`),
+    };
+  },
+  indent: function nestIndent(match, options) {
+    const indent = [_.get(options, 'extend.indent'), match[WHITESPACE_GROUP]];
+    return _(indent).filter(_.isString).value().join('');
+  },
+};
 
-export function getLink(match) {
-  const link = {
-    href: _.get(match, `[${LINK_GROUP}]`),
-  };
-  return link;
-}
-
-export function nestIndent(match, chunk) {
-  return '' + chunk.indent + match[WHITESPACE_GROUP];
-}
 
 export const BUNYAN_DEFAULTS = {
   file: {

--- a/src/inflate-stream.js
+++ b/src/inflate-stream.js
@@ -7,7 +7,7 @@ import RegexStream from '../lib/regex-stream';
 import ResolveStream from './resolve-stream';
 import TrimStream from './trim-stream';
 import grammar from './transclude-parser';
-import {DEFAULT_LOG, getLink, nestIndent, LINK_REGEXP, WHITESPACE_GROUP} from './config';
+import {DEFAULT_LOG, LINK_REGEXP, LINK_MATCH, WHITESPACE_GROUP} from './config';
 
 /**
 * Input stream: object
@@ -45,11 +45,8 @@ export default function InflateStream(options, log = DEFAULT_LOG) {
     const resolver = new ResolveStream(grammar, null, log);
     const inflater = new InflateStream(null, log);
     const trimmer = new TrimStream();
-    const tokenizer = new RegexStream(LINK_REGEXP, {
-      match: {
-        link: getLink,
-        indent: nestIndent,
-      },
+    const tokenizerOptions = {
+      match: LINK_MATCH,
       leaveBehind: `${WHITESPACE_GROUP}`,
       extend: {
         relativePath: chunk.relativePath,
@@ -57,7 +54,8 @@ export default function InflateStream(options, log = DEFAULT_LOG) {
         references: [...chunk.references],
         indent: indent,
       },
-    }, log);
+    };
+    const tokenizer = new RegexStream(LINK_REGEXP, tokenizerOptions, log);
 
     const self = this;
 

--- a/src/transclude-stream.js
+++ b/src/transclude-stream.js
@@ -9,7 +9,7 @@ import ResolveStream from './resolve-stream';
 import InflateStream from './inflate-stream';
 import IndentStream from './indent-stream';
 import grammar from './transclude-parser';
-import {getLink, LINK_REGEXP, WHITESPACE_GROUP} from './config';
+import {LINK_REGEXP, LINK_MATCH, WHITESPACE_GROUP} from './config';
 
 /**
 * Input stream: string
@@ -24,20 +24,17 @@ const DEFAULT_OPTIONS = {
 
 export default function Transcluder(options, log) {
   const opt = _.merge({}, DEFAULT_OPTIONS, options);
-  const extend = {
-    relativePath: opt.relativePath,
-    references: opt.references || [],
-    parents: opt.parents || [],
-    indent: opt.indent,
-  };
-  const tokenizer = new RegexStream(LINK_REGEXP, {
-    match: {
-      link: getLink,
-      indent: `${WHITESPACE_GROUP}`,
-    },
+  const tokenizerOptions = {
+    match: LINK_MATCH,
     leaveBehind: `${WHITESPACE_GROUP}`,
-    extend,
-  }, log);
+    extend: {
+      relativePath: opt.relativePath,
+      references: opt.references || [],
+      parents: opt.parents || [],
+      indent: opt.indent,
+    },
+  };
+  const tokenizer = new RegexStream(LINK_REGEXP, tokenizerOptions, log);
   const resolver = new ResolveStream(grammar, null, log);
   const inflater = new InflateStream(null, log);
   const indenter = new IndentStream(null, log);

--- a/test/regex-stream.js
+++ b/test/regex-stream.js
@@ -1,6 +1,5 @@
 import test from 'ava';
-import _ from 'lodash';
-import {LINK_REGEXP, LINK_GROUP, WHITESPACE_GROUP} from '../lib/config';
+import {LINK_REGEXP, LINK_MATCH, LINK_GROUP, WHITESPACE_GROUP} from '../lib/config';
 import RegexStream from '../lib/regex-stream';
 
 
@@ -160,11 +159,12 @@ test.cb('should return restructed match', (t) => {
   };
   const options = {
     match: {
-      link: `${LINK_GROUP}`,
-      indent: (match) => {
-        return ['__', _.get(match, `${WHITESPACE_GROUP}`)].join('');
-      },
+      link: `[${LINK_GROUP}]`,
+      indent: LINK_MATCH.indent,
       number: 2,
+    },
+    extend: {
+      indent: '__',
     },
   };
   const testStream = new RegexStream(LINK_REGEXP, options);
@@ -192,16 +192,15 @@ test.cb('should leave behind leading whitespace', (t) => {
       content: '  ',
     },
     {
-      content: '  :[foo](bar.md)',
-      link: 'bar.md',
+      content: ':[foo](bar.md)',
+      link: {
+        href: 'bar.md',
+      },
       indent: '  ',
     },
   ];
   const options = {
-    match: {
-      link: `${LINK_GROUP}`,
-      indent: `${WHITESPACE_GROUP}`,
-    },
+    match: LINK_MATCH,
     leaveBehind: `${WHITESPACE_GROUP}`,
   };
   const testStream = new RegexStream(LINK_REGEXP, options);


### PR DESCRIPTION
- Fix issue where chunk.content also included indent. If resolve or
inflate failed, extra white space would be added before the link.
- Refactored config for regex-stream.