### PR TITLE
Build: add commit-msg validation (refs #95)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,39 @@ The process of submitting a pull request is fairly straightforward and generally
 
 ## Commit conventions
 
-todo
+Our commit message format is as follows:
 
-## Test coverage
+```
+Tag: Short description (fixes #1234)
 
-todo
+Longer description here if necessary
+The first line of the commit message (the summary) must have a specific format. This format is checked by our build tools.
+```
 
-## Code style
+The `Tag` is one of the following:
 
-todo
+- `Fix` - for a bug fix.
+- `New` - implemented a new feature.
+- `Update` - for a backwards-compatible enhancement.
+- `Breaking` - for a backwards-incompatible enhancement or feature.
+- `Docs` - changes to documentation only.
+- `Build` - changes to build process only.
+- `Upgrade` - for a dependency upgrade.
+
+The message summary should be a one-sentence description of the change, and it must be 72 characters in length or shorter. The issue number should be mentioned at the end. If the commit doesn't completely fix the issue, then use (`refs #1234`) instead of (`fixes #1234`).
+
+Here are some good commit message summary examples:
+
+```
+Build: Update Travis to only test Node 0.10 (refs #734)
+Fix: Special characters in link label causing parse error (fixes #840)
+Upgrade: through2 to 2.0.0 (fixes #730)
+```
+
+The commit message format is important because these messages are used to create a changelog for each release. The tag and issue number help to create more consistent and useful changelogs.
+
+## Code style and test coverage
+
+All code should be simple, self documenting, and fully unit tested.
+
+Please make sure all tests are passing locally, including code linting.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Markdown, API Blueprint and string transclusion",
   "main": "./lib/hercule",
   "scripts": {
-    "test": "npm run compile && npm run test-units && npm run test-integration && npm run test-cli",
+    "test": "npm run compile && npm run test-units && npm run test-integration && npm run test-cli && npm run check-commit",
     "test-units": "./node_modules/.bin/nyc --reporter=json ./node_modules/.bin/ava",
     "test-integration": "./node_modules/.bin/ava test/integration",
     "test-cli": "./test/modules/bin/bats test/bats",
@@ -13,7 +13,8 @@
     "codecov": "cat coverage/coverage-final.json | ./node_modules/.bin/codecov",
     "compile": "BABEL_ENV=compile ./node_modules/.bin/babel src --out-dir lib --source-maps && ./node_modules/.bin/pegjs src/transclude.pegjs lib/transclude-parser.js",
     "install-bats": "./scripts/install-bats",
-    "lint": "./node_modules/.bin/eslint ./src ./test"
+    "lint": "./node_modules/.bin/eslint ./src ./test",
+    "check-commit": "./scripts/commit-msg"
   },
   "config": {
     "nyc": {
@@ -69,7 +70,9 @@
     "istanbul": "^0.4.1",
     "nock": "^3.0.0",
     "nyc": "^5.0.0",
-    "pegjs": "^0.9.0"
+    "pegjs": "^0.9.0",
+    "semver": "^5.1.0",
+    "shelljs": "^0.5.3"
   },
   "publishConfig": {
     "tag": "next"

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+require("shelljs/make");
+
+var semver = require("semver");
+'use strict';
+
+var TAG_REGEX = /^(?:Fix|Update|Breaking|Docs|Build|New|Upgrade):/;
+var ISSUE_REGEX = /\((?:fixes|refs) #\d+(?:.*(?:fixes|refs) #\d+)*\)$/;
+
+/**
+ * Executes a command and returns the output instead of printing it to stdout.
+ * @param {string} cmd The command string to execute.
+ * @returns {string} The result of the executed command.
+ */
+function execSilent(cmd) {
+    return exec(cmd, { silent: true }).output;
+}
+
+/**
+ * Splits a command result to separate lines.
+ * @param {string} result The command result string.
+ * @returns {array} The separated lines.
+ */
+function splitCommandResultToLines(result) {
+    return result.trim().split("\n");
+}
+
+/**
+ * Check if the branch name is valid
+ * @param {string} branchName Branch name to check
+ * @returns {boolean} true is branch exists
+ * @private
+ */
+function hasBranch(branchName) {
+    var branches = getBranches();
+    return branches.indexOf(branchName) !== -1;
+}
+
+/**
+ * Returns all the branch names
+ * @returns {string[]} branch names
+ * @private
+ */
+function getBranches() {
+    var branchesRaw = splitCommandResultToLines(execSilent("git branch --list")),
+        branches = [],
+        branchName;
+
+    for (var i = 0; i < branchesRaw.length; i++) {
+        branchName = branchesRaw[i].replace(/^\*(.*)/, "$1").trim();
+        branches.push(branchName);
+    }
+    return branches;
+}
+
+function checkGitCommit() {
+  var commitMsgs, failed;
+
+  if (hasBranch("master-v2")) {
+    commitMsgs = splitCommandResultToLines(execSilent("git log HEAD --not master-v2 --format=format:%s --no-merges"));
+  } else {
+    commitMsgs = [execSilent("git log -1 --format=format:%s --no-merges")];
+  }
+
+  echo("Validating Commit Message");
+
+  // No commit since master should not cause test to fail
+  if (commitMsgs[0] === "") {
+    return;
+  }
+
+  // Check for more than one commit
+  if (commitMsgs.length > 1) {
+    echo(" - More than one commit found, please squash.");
+    failed = true;
+  }
+
+  // Only check non-release messages
+  if (!semver.valid(commitMsgs[0]) && !/^Revert /.test(commitMsgs[0])) {
+    if (commitMsgs[0].slice(0, commitMsgs[0].indexOf("\n")).length > 72) {
+      echo(" - First line of commit message must not exceed 72 characters");
+      failed = true;
+    }
+
+    // Check for tag at start of message
+    if (!TAG_REGEX.test(commitMsgs[0])) {
+      echo([" - Commit summary must start with one of:",
+        "    'Fix:'",
+        "    'Update:'",
+        "    'Breaking:'",
+        "    'Docs:'",
+        "    'Build:'",
+        "    'New:'",
+        "    'Upgrade:'",
+        "   Please refer to the contribution guidelines for more details."].join("\n"));
+      failed = true;
+    }
+
+    // Check for an issue reference at end (unless it's a documentation commit)
+    if (!/^Docs:/.test(commitMsgs[0])) {
+      if (!ISSUE_REGEX.test(commitMsgs[0])) {
+        echo([" - Commit summary must end with with one of:",
+          "    '(fixes #1234)'",
+          "    '(refs #1234)'",
+          "   Where '1234' is the issue being addressed.",
+          "   Please refer to the contribution guidelines for more details."].join("\n"));
+        failed = true;
+      }
+    }
+  }
+
+  if (failed) {
+    exit(1);
+  }
+}
+
+checkGitCommit();


### PR DESCRIPTION
Uses ESLint commit style: http://eslint.org/docs/developer-guide/contributing/pull-requests#step2

Previously had been using the angular commit style for v2. In practice it feels more cumbersome than the ESLint style, and given the much smaller project size, the advantages of the angular style are outweighed.