### PR TITLE
Update: ava 0.9.1

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,3 @@
 {
-  "env": {
-    "compile": {
-      "presets": ["es2015"]
-    }
-  }
+  "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "main": "./lib/hercule",
   "scripts": {
     "test": "npm run compile && npm run test-units && npm run test-integration && npm run test-cli && npm run check-commit",
-    "test-units": "./node_modules/.bin/nyc --reporter=json ./node_modules/.bin/ava",
-    "test-integration": "./node_modules/.bin/ava test/integration",
+    "test-units": "nyc --reporter=json ava test/units",
+    "test-integration": "ava test/integration",
     "test-cli": "./test/modules/bin/bats test/bats",
     "posttest": "npm run lint",
-    "coverage": "./node_modules/.bin/istanbul report --reporter=html && open coverage/lcov-report/index.html",
-    "codecov": "cat coverage/coverage-final.json | ./node_modules/.bin/codecov",
-    "compile": "BABEL_ENV=compile ./node_modules/.bin/babel src --out-dir lib --source-maps && ./node_modules/.bin/pegjs src/transclude.pegjs lib/transclude-parser.js",
+    "coverage": "istanbul report --reporter=html && open coverage/lcov-report/index.html",
+    "codecov": "cat coverage/coverage-final.json | codecov",
+    "compile": "babel src --out-dir lib --source-maps && pegjs src/transclude.pegjs lib/transclude-parser.js",
+    "lint": "eslint ./src ./test",
     "install-bats": "./scripts/install-bats",
-    "lint": "./node_modules/.bin/eslint ./src ./test",
     "check-commit": "./scripts/commit-msg"
   },
   "config": {
@@ -60,7 +60,7 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
-    "ava": "^0.8.0",
+    "ava": "^0.9.1",
     "babel-cli": "^6.2.0",
     "babel-preset-es2015": "^6.1.18",
     "codecov.io": "^0.1.6",

--- a/test/units/indent-stream.js
+++ b/test/units/indent-stream.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import IndentStream from '../lib/indent-stream';
+import IndentStream from '../../lib/indent-stream';
 
 
 test.cb('should handle no input', (t) => {

--- a/test/units/inflate-stream.js
+++ b/test/units/inflate-stream.js
@@ -1,6 +1,7 @@
+import path from 'path';
 import test from 'ava';
 import nock from 'nock';
-import InflateStream from '../lib/inflate-stream';
+import InflateStream from '../../lib/inflate-stream';
 
 
 test.cb('should handle no input', (t) => {
@@ -46,7 +47,7 @@ test.cb('should inflate input with file link', (t) => {
   const input = {
     content: ':[Example](size.md)',
     link: {
-      href: __dirname + '/fixtures/local-link/size.md',
+      href: path.join(__dirname, '../fixtures/local-link/size.md'),
       hrefType: 'file',
     },
     parents: [],
@@ -75,7 +76,7 @@ test.cb('should skip input with invalid file link', (t) => {
   const input = {
     content: ':[Example](size.md)',
     link: {
-      href: __dirname + '/i-dont-exist.md',
+      href: path.join(__dirname, '/i-dont-exist.md'),
       hrefType: 'file',
     },
     parents: [],

--- a/test/units/regex-stream.js
+++ b/test/units/regex-stream.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import {LINK_REGEXP, LINK_MATCH, LINK_GROUP, WHITESPACE_GROUP} from '../lib/config';
-import RegexStream from '../lib/regex-stream';
+import {LINK_REGEXP, LINK_MATCH, LINK_GROUP, WHITESPACE_GROUP} from '../../lib/config';
+import RegexStream from '../../lib/regex-stream';
 
 
 test.cb('should find handle empty buffer', (t) => {

--- a/test/units/resolve-stream.js
+++ b/test/units/resolve-stream.js
@@ -1,6 +1,6 @@
 import test from 'ava';
-import grammar from '../lib/transclude-parser';
-import ResolveStream from '../lib/resolve-stream';
+import grammar from '../../lib/transclude-parser';
+import ResolveStream from '../../lib/resolve-stream';
 
 
 test.cb('should handle no input', (t) => {

--- a/test/units/trim-stream.js
+++ b/test/units/trim-stream.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import TrimStream from '../lib/trim-stream';
+import TrimStream from '../../lib/trim-stream';
 
 
 test.cb('should handle no input', (t) => {


### PR DESCRIPTION
- Breaking change to handling of nested tests. Unit and integration tests
are now in separate non-nested directories.
- Babel 6 is now being used by ava removing the need for .babelrc to be
scoped to compile time