### PR TITLE
New: ability to pass in pathList variable (closes #196)

### DIFF
--- a/src/hercule.js
+++ b/src/hercule.js
@@ -27,9 +27,9 @@ export const TranscludeStream = Transcluder;
 export function transcludeString(...args) {
   const input = args.shift();
   const cb = args.pop();
-  const [options, log] = args;
+  const [options, log, linkPaths] = args;
 
-  const transclude = new Transcluder(options, log);
+  const transclude = new Transcluder(options, log, linkPaths);
   let outputString = '';
 
   transclude.on('error', (err) => cb(err));
@@ -51,9 +51,9 @@ export function transcludeString(...args) {
 export function transcludeFile(...args) {
   const input = args.shift();
   const cb = args.pop();
-  const [options, log] = args;
+  const [options, log, linkPaths] = args;
 
-  const transclude = new Transcluder(options, log);
+  const transclude = new Transcluder(options, log, linkPaths);
   const inputStream = fs.createReadStream(input, { encoding: 'utf8' });
   let outputString = '';
 

--- a/src/inflate-stream.js
+++ b/src/inflate-stream.js
@@ -30,11 +30,11 @@ const DEFAULT_OPTIONS = {
   output: 'content',
 };
 
-export default function InflateStream(opt, log = DEFAULT_LOG) {
+export default function InflateStream(opt, log = DEFAULT_LOG, linkPaths) {
   const options = _.merge({}, DEFAULT_OPTIONS, opt);
 
   function inflateDuplex(chunk, link) {
-    const resolver = new ResolveStream(grammar, null, log);
+    const resolver = new ResolveStream(grammar, null, log, linkPaths);
     const inflater = new InflateStream(null, log);
     const trimmer = new TrimStream();
     const tokenizerOptions = {
@@ -73,7 +73,6 @@ export default function InflateStream(opt, log = DEFAULT_LOG) {
       return cb();
     }
 
-    // ES2016: Array.includes()
     if (_(parents).includes(link.href)) {
       log.error({ link }, 'Circular dependency detected');
       this.push(chunk);

--- a/src/resolve-stream.js
+++ b/src/resolve-stream.js
@@ -26,7 +26,7 @@ const DEFAULT_OPTIONS = {
 };
 
 
-export default function ResolveStream(grammar, opt, log = DEFAULT_LOG) {
+export default function ResolveStream(grammar, opt, log = DEFAULT_LOG, linkPaths = []) {
   const options = _.merge({}, DEFAULT_OPTIONS, opt);
 
 
@@ -76,6 +76,8 @@ export default function ResolveStream(grammar, opt, log = DEFAULT_LOG) {
 
     references = _.uniq([...references, ...parentRefs], true);
     link = resolve(link, parentRefs, relativePath);
+
+    linkPaths.push(link.href);
 
     this.push(_.assign(chunk, { [options.output]: link }, { references }));
     return cb();

--- a/src/transclude-stream.js
+++ b/src/transclude-stream.js
@@ -20,7 +20,7 @@ const DEFAULT_OPTIONS = {
   output: 'content',
 };
 
-export default function Transcluder(opt, log) {
+export default function Transcluder(opt, log, linkPaths) {
   const options = _.merge({}, DEFAULT_OPTIONS, opt);
   const tokenizerOptions = {
     leaveBehind: `${WHITESPACE_GROUP}`,
@@ -40,8 +40,8 @@ export default function Transcluder(opt, log) {
     }),
   };
   const tokenizer = regexpTokenizer(tokenizerOptions, LINK_REGEXP);
-  const resolver = new ResolveStream(grammar, null, log);
-  const inflater = new InflateStream(null, log);
+  const resolver = new ResolveStream(grammar, null, log, linkPaths);
+  const inflater = new InflateStream(null, log, linkPaths);
   const indenter = new IndentStream(null, log);
   const stringify = get('content');
 

--- a/test/units/transcludeFile.js
+++ b/test/units/transcludeFile.js
@@ -39,9 +39,24 @@ test.cb('should transclude with optional log handler', (t) => {
 
 test.cb('should return error if file doesn\'t exist', (t) => {
   const input = path.join('i-dont-exist.md');
-  transcludeFile(input, null, (err, output) => {
+  transcludeFile(input, null, null, (err, output) => {
     t.ok(err);
     t.notOk(output);
+    t.end();
+  });
+});
+
+test.cb('should provide pathList if variable provided', (t) => {
+  const input = path.join(__dirname, '../fixtures/local-link/index.md');
+  const options = { relativePath: path.join(__dirname, '../fixtures/local-link') };
+  const expected = 'Jackdaws love my big sphinx of quartz.\n';
+  const pathList = [];
+
+  transcludeFile(input, options, null, pathList, (err, output) => {
+    t.same(err, null);
+    t.same(output, expected);
+    t.regex(pathList[0], /fixtures\/local-link\/size\.md/);
+    t.same(pathList.length, 1);
     t.end();
   });
 });

--- a/test/units/transcludeString.js
+++ b/test/units/transcludeString.js
@@ -35,3 +35,16 @@ test.cb('should transclude with optional log handler', (t) => {
     t.end();
   });
 });
+
+test.cb('should provide pathList if variable provided', (t) => {
+  const input = 'The quick brown fox jumps over the lazy dog.';
+  const expected = 'The quick brown fox jumps over the lazy dog.';
+  const pathList = [];
+
+  transcludeString(input, null, null, pathList, (err, output) => {
+    t.same(err, null);
+    t.same(output, expected);
+    t.same(pathList.length, 0);
+    t.end();
+  });
+});


### PR DESCRIPTION
Retrieving the list of all paths included in the output file is useful for live reload applications where all the source files must be watched to trigger regeneration of the output and an update watch list.