### PR TITLE
Improved API for accessing sourceFilePaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,12 +229,11 @@ __Arguments__
 - `str` - A string to process.
 - `options` - An object of options to be applied when processing input.
   - `relativePath` - A path to which the transclusion links within input `str` are relative.
-- `pathList` - An array (typically empty) which the path of every transclusion will be appended to.
-  This is helpful for generating a watch list for live reloading.
-- `callback(err, [output])` - A callback which is called after the file at the provided `filepath`
-  has been processed. `callback` will be passed an error and the processed output.
+- `callback(err, [output], [sourcePaths])` - A callback which is called after the input `str` has been processed.
+  `callback` will be passed an error, processed output and array of source document file paths.
 
-Omit the `callback` and `pathList` if using `transcludeStringSync`.
+
+Omit the `callback` if using `transcludeStringSync`. Only `output` will be returned.
 
 __Examples__
 
@@ -276,12 +275,10 @@ __Arguments__
 - `filepath` - A path to a file to process.
 - `options` - An object of options to be applied when processing input.
   - `relativePath` - A path to which the input `filepath` is relative.
-- `pathList` - An array (typically empty) which the path of every transclusion will be appended to.
-  This is helpful for generating a watch list for live reloading.
-- `callback(err, [output])` - A callback which is called after the file at the provided `filepath`
-  has been processed. `callback` will be passed an error and the processed output.
+- `callback(err, [output], [sourcePaths])` - A callback which is called after the file at the provided `filepath`
+  has been processed. `callback` will be passed an error, processed output and array of source document file paths.
 
-Omit the `callback` and `pathList` if using `transcludeFileSync`.
+Omit the `callback` if using `transcludeFileSync`. Only `output` will be returned.
 
 __Examples__
 

--- a/src/hercule.js
+++ b/src/hercule.js
@@ -11,10 +11,11 @@ export const TranscludeStream = Transcluder;
 export function transcludeString(...args) {
   const input = args.shift();
   const cb = args.pop();
-  const [options, linkPaths] = args;
+  const [options] = args;
 
-  const transclude = new Transcluder(options, linkPaths);
+  const transclude = new Transcluder(options);
   let outputString = '';
+  let sourcePaths;
   let cbErr = null;
 
   transclude
@@ -27,7 +28,8 @@ export function transcludeString(...args) {
     .on('error', (err) => {
       if (!cbErr) cbErr = err;
     })
-    .on('end', () => cb(cbErr, outputString));
+    .on('sources', (srcPaths) => (sourcePaths = srcPaths))
+    .on('end', () => cb(cbErr, outputString, sourcePaths));
 
   transclude.write(input, 'utf8');
   transclude.end();
@@ -37,11 +39,12 @@ export function transcludeString(...args) {
 export function transcludeFile(...args) {
   const input = args.shift();
   const cb = args.pop();
-  const [options, linkPaths] = args;
+  const [options] = args;
 
-  const transclude = new Transcluder(options, linkPaths);
+  const transclude = new Transcluder(options);
   const inputStream = fs.createReadStream(input, { encoding: 'utf8' });
   let outputString = '';
+  let sourcePaths;
   let cbErr = null;
 
   inputStream.on('error', (err) => cb(err));
@@ -56,7 +59,8 @@ export function transcludeFile(...args) {
     .on('error', (err) => {
       if (!cbErr) cbErr = err;
     })
-    .on('end', () => cb(cbErr, outputString));
+    .on('sources', (srcPaths) => (sourcePaths = srcPaths))
+    .on('end', () => cb(cbErr, outputString, sourcePaths));
 
   inputStream.pipe(transclude);
 }

--- a/src/inflate-stream.js
+++ b/src/inflate-stream.js
@@ -31,11 +31,11 @@ const DEFAULT_OPTIONS = {
   output: 'content',
 };
 
-export default function InflateStream(opt, linkPaths) {
+export default function InflateStream(opt) {
   const options = _.merge({}, DEFAULT_OPTIONS, opt);
 
   function inflateDuplex(chunk, link) {
-    const resolver = new ResolveStream(link.href, linkPaths);
+    const resolver = new ResolveStream(link.href);
     const inflater = new InflateStream();
     const trimmer = new TrimStream();
 

--- a/src/resolve-stream.js
+++ b/src/resolve-stream.js
@@ -60,7 +60,7 @@ function parse(rawLink, relativePath) {
   return { parsedLink, parsedReferences };
 }
 
-export default function ResolveStream(sourceFile, sourcePaths = []) {
+export default function ResolveStream() {
   function transform(chunk, encoding, cb) {
     const rawLink = _.get(chunk, ['link', 'href']);
     const relativePath = _.get(chunk, 'relativePath') || '';
@@ -85,9 +85,7 @@ export default function ResolveStream(sourceFile, sourcePaths = []) {
     const references = _.uniq([...parsedReferences, ...parentRefs]);
     const link = resolve(parsedLink, parentRefs, relativePath);
 
-    // Add the resolved link path to the array of all source paths
-    sourcePaths.push(link.href);
-
+    this.emit('source', link.href);
     this.push(_.assign(chunk, { link, references }));
     return cb();
   }

--- a/test/units/transcludeFile.js
+++ b/test/units/transcludeFile.js
@@ -58,17 +58,16 @@ test.cb('should return one error if invalid links found', (t) => {
   });
 });
 
-test.cb('should provide pathList if variable provided', (t) => {
+test.cb('should return sourceList', (t) => {
   const input = path.join(__dirname, '../fixtures/local-link/index.md');
   const options = { relativePath: path.join(__dirname, '../fixtures/local-link') };
   const expected = 'Jackdaws love my big sphinx of quartz.\n';
-  const pathList = [];
 
-  transcludeFile(input, options, pathList, (err, output) => {
+  transcludeFile(input, options, (err, output, sourceList) => {
     t.same(err, null);
     t.same(output, expected);
-    t.regex(pathList[0], /fixtures\/local-link\/size\.md/);
-    t.same(pathList.length, 1);
+    t.regex(sourceList[0], /fixtures\/local-link\/size\.md/);
+    t.same(sourceList.length, 1);
     t.end();
   });
 });

--- a/test/units/transcludeString.js
+++ b/test/units/transcludeString.js
@@ -23,15 +23,15 @@ test.cb('should transclude with optional relativePath argument', (t) => {
   });
 });
 
-test.cb('should provide pathList if variable provided', (t) => {
-  const input = 'The quick brown fox jumps over the lazy dog.';
-  const expected = 'The quick brown fox jumps over the lazy dog.';
-  const pathList = [];
+test.cb('should return sourceList', (t) => {
+  const input = 'Jackdaws love my :[size link](size.md) sphinx of quartz.';
+  const options = { relativePath: path.join(__dirname, '../fixtures/local-link') };
+  const expected = 'Jackdaws love my big sphinx of quartz.';
 
-  transcludeString(input, null, pathList, (err, output) => {
+  transcludeString(input, options, (err, output, sourceList) => {
     t.same(err, null);
     t.same(output, expected);
-    t.same(pathList.length, 0);
+    t.same(sourceList.length, 1);
     t.end();
   });
 });


### PR DESCRIPTION
Accessing the pathList by providing an error is very hackish and fragile approach.

Implementation has been updated to emit `sources` event from the core transclusion stream which is then captured and provided as an argument to the callback.