### PR TITLE
Update: string inflater returns an object rather than a text stream.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "dashdash": "^1.10.1",
     "duplexer2": "^0.1.4",
     "lodash": "^4.0.0",
-    "regexp-stream-tokenizer": "^0.1.1",
+    "regexp-stream-tokenizer": "^0.2.0",
     "request": "^2.65.0",
     "through2": "^2.0.0",
     "through2-get": "^0.0.2"

--- a/src/hercule.js
+++ b/src/hercule.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import childProcess from 'child_process';
 import _ from 'lodash';
 
@@ -12,8 +13,10 @@ export function transcludeString(...args) {
   const input = args.shift();
   const cb = args.pop();
   const [options] = args;
+  const relativePath = _.get(options, 'relativePath');
+  const source = relativePath ? `${options.relativePath}/string` : 'string';
 
-  const transclude = new Transcluder(options);
+  const transclude = new Transcluder(source, options);
   let outputString = '';
   let sourcePaths;
   let cbErr = null;
@@ -39,9 +42,10 @@ export function transcludeString(...args) {
 export function transcludeFile(...args) {
   const input = args.shift();
   const cb = args.pop();
-  const [options] = args;
+  const [options = {}] = args;
+  if (!_.get(options, 'relativePath')) options.relativePath = path.basename(input);
 
-  const transclude = new Transcluder(options);
+  const transclude = new Transcluder(input, options);
   const inputStream = fs.createReadStream(input, { encoding: 'utf8' });
   let outputString = '';
   let sourcePaths;

--- a/src/inflaters/string.js
+++ b/src/inflaters/string.js
@@ -1,8 +1,13 @@
 import { Readable } from 'stream';
 
-export default function inflate(content) {
-  const stringStream = new Readable;
-  stringStream.push(content);
+/**
+ * String transclusion is trigered by strings inside the transclusion link, and cannot contain links themselves.
+ *
+ * This will also simplify handling of reference and fallback expansion strings.
+ */
+export default function inflate(content, source) {
+  const stringStream = new Readable({ objectMode: true });
+  stringStream.push({ content, source });
   stringStream.push(null);
   return stringStream;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 /**
 * Hercule
 * A simple markdown transclusion tool
-* Author: james ramsay
+* Author: James Ramsay
 */
 
 import fs from 'fs';
@@ -57,8 +57,8 @@ if (opts.help) {
 function main() {
   let inputStream;
   let outputStream;
+  let source;
   const options = {
-    relativePath: '',
     parents: [],
     parentRefs: [],
   };
@@ -66,13 +66,12 @@ function main() {
   if (args.length === 0) {
     // Reading input from stdin
     inputStream = process.stdin;
+    source = `${opts.relativePath}/stdin.md`;
     options.relativePath = opts.relativePath;
   } else {
     // Reading input from file
-    // TODO: handle file error!
-    inputStream = fs.createReadStream(args[0], { encoding: 'utf8' });
-    options.source = path.normalize(args[0]);
-    options.relativePath = path.dirname(args[0]);
+    source = path.normalize(args[0]);
+    inputStream = fs.createReadStream(source, { encoding: 'utf8' });
   }
 
   if (opts.output) {
@@ -83,7 +82,7 @@ function main() {
     outputStream = process.stdout;
   }
 
-  const transclude = new Transcluder(options);
+  const transclude = new Transcluder(source, options);
 
   transclude.on('error', (err) => {
     if (opts.reporter === 'json-err') {

--- a/src/transclude-stream.js
+++ b/src/transclude-stream.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import _ from 'lodash';
 import duplexer from 'duplexer2';
 import get from 'through2-get';
@@ -18,8 +20,8 @@ const DEFAULT_OPTIONS = {
   output: 'content',
 };
 
-export default function Transcluder(opt) {
-  const options = _.merge({}, DEFAULT_OPTIONS, opt);
+export default function Transcluder(source, opt) {
+  const options = _.merge({}, DEFAULT_OPTIONS, { relativePath: path.dirname(source) }, opt);
   const sourcePaths = [];
 
   function token(match) {
@@ -33,7 +35,7 @@ export default function Transcluder(opt) {
   const tokenizerOptions = { leaveBehind: `${WHITESPACE_GROUP}`, token, separator };
   const linkRegExp = _.get(options, 'linkRegExp') || defaultTokenRegExp;
   const tokenizer = regexpTokenizer(tokenizerOptions, linkRegExp);
-  const resolver = new ResolveStream({ linkRegExp: options.linkRegExp, linkMatch: options.linkMatch });
+  const resolver = new ResolveStream(source, { linkRegExp: options.linkRegExp, linkMatch: options.linkMatch });
   const indenter = new IndentStream();
   const stringify = get('content');
 

--- a/src/trim-stream.js
+++ b/src/trim-stream.js
@@ -1,4 +1,5 @@
 import through2 from 'through2';
+import _ from 'lodash';
 
 /**
 * Trims new line at EOF to allow a file to be transcluded inline.
@@ -14,6 +15,11 @@ export default function TrimStream() {
   let inputBuffer = '';
 
   function transform(chunk, encoding, cb) {
+    // Allow objects to be passed through unaltered
+    if (!_.isString(chunk) && !_.isBuffer(chunk)) {
+      return cb(null, chunk);
+    }
+
     const input = chunk.toString('utf8');
 
     // Combine buffer and new input

--- a/test/integration/transcludeStream.js
+++ b/test/integration/transcludeStream.js
@@ -11,7 +11,7 @@ _.forEach((fixtures.fixtures), (fixture) => {
   test.cb(`should transclude ${fixture.name}`, (t) => {
     const input = fs.createReadStream(fixture.inputFile, { encoding: 'utf8' });
     const options = { relativePath: path.dirname(fixture.inputFile) };
-    const transclude = new TranscludeStream(options, t.context.log);
+    const transclude = new TranscludeStream(fixture.inputFile, options);
     const config = fixture.expectedConfig;
     let outputString = '';
 

--- a/test/units/inflaters/string.js
+++ b/test/units/inflaters/string.js
@@ -1,0 +1,16 @@
+import test from 'ava';
+import stringInflater from '../../../src/inflaters/string';
+
+test.cb('should return exactly one object', (t) => {
+  const content = 'Quick brown fox';
+  const source = 'animal.md';
+  const testStream = stringInflater(content, source);
+
+  t.plan(1);
+
+  testStream.on('readable', function read() {
+    t.deepEqual(this.read(), { content, source });
+  });
+
+  testStream.on('end', () => t.end());
+});

--- a/test/units/resolve-stream.js
+++ b/test/units/resolve-stream.js
@@ -71,7 +71,6 @@ test.cb('should resolve simple link to content and emit source', (t) => {
     content: 'fox',
     line: 1,
     column: 0,
-    source: '/foo/fox.md',
   };
   const testStream = new ResolveStream();
 
@@ -109,22 +108,3 @@ test.cb('should emit error if circular dependency detected', (t) => {
   testStream.write(input);
   testStream.end();
 });
-
-// test.cb('should emit error if nested link is invalid', (t) => {
-//   const input = {
-//     content: ':[](animal.md)',
-//     link: 'animal.md',
-//     relativePath: '/foo',
-//   };
-//   const testStream = new ResolveStream();
-//
-//   t.plan(1);
-//   testStream.on('readable', function read() {
-//     this.read();
-//   });
-//   testStream.on('error', () => t.pass());
-//   testStream.on('end', () => t.end());
-//
-//   testStream.write(input);
-//   testStream.end();
-// });

--- a/test/units/resolve/parseLink.js
+++ b/test/units/resolve/parseLink.js
@@ -27,8 +27,9 @@ test.after(() => {
 test.cb('should resolve local file link', (t) => {
   const link = 'animal.md';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
 
-  resolveLink(link, relativePath, (err, input, resolvedLink, resolvedRelativePath) => {
+  resolveLink({ link, relativePath, source }, (err, input, resolvedLink, resolvedRelativePath) => {
     t.ifError(err);
     t.deepEqual(resolvedLink, '/foo/animal.md');
     t.deepEqual(resolvedRelativePath, relativePath);
@@ -45,8 +46,9 @@ test.cb('should resolve local file link', (t) => {
 test.cb('should resolve http link', (t) => {
   const link = 'http://github.com/a.md';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
 
-  resolveLink(link, relativePath, (err, input, resolvedLink, resolvedRelativePath) => {
+  resolveLink({ link, relativePath, source }, (err, input, resolvedLink, resolvedRelativePath) => {
     t.ifError(err);
     t.deepEqual(resolvedLink, link);
     t.deepEqual(resolvedRelativePath, link);
@@ -63,8 +65,9 @@ test.cb('should resolve http link', (t) => {
 test.cb('should emit error on invalid http link', (t) => {
   const link = 'http://github.com/i-dont-exist.md';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
 
-  resolveLink(link, relativePath, (err, input) => {
+  resolveLink({ link, relativePath, source }, (err, input) => {
     input.on('error', (inputErr) => {
       t.deepEqual(inputErr.message, 'Could not read file');
       t.deepEqual(inputErr.path, link);
@@ -82,14 +85,17 @@ test.cb('should emit error on invalid http link', (t) => {
 test.cb('should resolve string link', (t) => {
   const link = '"foo bar"';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
 
-  resolveLink(link, relativePath, (err, input, resolvedLink, resolvedRelativePath) => {
+  resolveLink({ link, relativePath, source }, (err, input, resolvedLink, resolvedRelativePath) => {
     t.ifError(err);
     t.deepEqual(resolvedLink, null);
     t.deepEqual(resolvedRelativePath, null);
 
+    input.on('error', () => t.fail());
+
     const concatStream = concat((result) => {
-      t.deepEqual(result.toString('utf8'), 'foo bar');
+      t.deepEqual(result, [{ content: 'foo bar', source }]);
       t.end();
     });
 

--- a/test/units/resolve/parseTransclude.js
+++ b/test/units/resolve/parseTransclude.js
@@ -4,11 +4,11 @@ import { parseTransclude } from '../../../src/resolve';
 test.cb('should parse simple link', (t) => {
   const link = 'animal.md';
   const relativePath = '/foo';
-  const expectedLink = 'animal.md';
+  const source = '/foo/bar.md';
 
-  parseTransclude(link, relativePath, (err, primary, fallback, references) => {
+  parseTransclude(link, relativePath, source, (err, primary, fallback, references) => {
     t.ifError(err);
-    t.deepEqual(primary, { link: expectedLink, relativePath });
+    t.deepEqual(primary, { link, relativePath, source });
     t.falsy(fallback);
     t.deepEqual(references, []);
     t.end();
@@ -18,13 +18,14 @@ test.cb('should parse simple link', (t) => {
 test.cb('should parse input with fallback', (t) => {
   const link = 'animal || wolf.md';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
   const expectedPrimary = 'animal';
   const expectedFallback = 'wolf.md';
 
-  parseTransclude(link, relativePath, (err, primary, fallback, references) => {
+  parseTransclude(link, relativePath, source, (err, primary, fallback, references) => {
     t.ifError(err);
-    t.deepEqual(primary, { link: expectedPrimary, relativePath });
-    t.deepEqual(fallback, { link: expectedFallback, relativePath });
+    t.deepEqual(primary, { link: expectedPrimary, relativePath, source });
+    t.deepEqual(fallback, { link: expectedFallback, relativePath, source });
     t.deepEqual(references, []);
     t.end();
   });
@@ -33,23 +34,26 @@ test.cb('should parse input with fallback', (t) => {
 test.cb('should parse input with references', (t) => {
   const link = 'animal canis:wolf.md vulpes:http://en.wikipedia.org/wiki/Fox';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
   const expectedPrimary = 'animal';
   const expectedReferences = [
     {
       placeholder: 'canis',
       link: 'wolf.md',
       relativePath,
+      source,
     },
     {
       placeholder: 'vulpes',
       link: 'http://en.wikipedia.org/wiki/Fox',
       relativePath,
+      source,
     },
   ];
 
-  parseTransclude(link, relativePath, (err, primary, fallback, references) => {
+  parseTransclude(link, relativePath, source, (err, primary, fallback, references) => {
     t.ifError(err);
-    t.deepEqual(primary, { link: expectedPrimary, relativePath });
+    t.deepEqual(primary, { link: expectedPrimary, relativePath, source });
     t.falsy(fallback);
     t.deepEqual(references, expectedReferences);
     t.end();
@@ -59,8 +63,9 @@ test.cb('should parse input with references', (t) => {
 test.cb('should return error if link cannot be parsed', (t) => {
   const link = 'animal.md :dog:cat';
   const relativePath = '/foo';
+  const source = '/foo/bar.md';
 
-  parseTransclude(link, relativePath, (err) => {
+  parseTransclude(link, relativePath, source, (err) => {
     t.truthy(err);
     t.end();
   });

--- a/test/units/trim-stream.js
+++ b/test/units/trim-stream.js
@@ -18,6 +18,24 @@ test.cb('should handle no input', (t) => {
 });
 
 
+test.cb('should not modify object chunks', (t) => {
+  const input = { content: 'The quick brown fox jumps over the lazy dog.' };
+  const testStream = new TrimStream();
+
+  testStream.on('readable', function read() {
+    let chunk = null;
+    while ((chunk = this.read()) !== null) {
+      t.deepEqual(chunk, input);
+    }
+  });
+
+  testStream.on('end', () => t.end());
+
+  testStream.write(input);
+  testStream.end();
+});
+
+
 test.cb('should not modify input without trailing new line', (t) => {
   const input = 'The quick brown fox jumps over the lazy dog.';
   const testStream = new TrimStream();


### PR DESCRIPTION
This allows reference sources to easily be propagated for use in sourcemaps.