### PR TITLE
Update: refactor inflaters to handle trimming

### DIFF
--- a/src/inflaters/http.js
+++ b/src/inflaters/http.js
@@ -1,10 +1,24 @@
 import request from 'request';
+import duplexer from 'duplexer2';
+import TrimStream from '../trim-stream';
 
+/**
+ * HTTP link inflater
+ *
+ * Simply returns readable stream of the HTTP link with trailing new line removed.
+ * This allows inline transclusion by stripping traiing new line at EOF.
+ */
 export default function inflate(link) {
-  return request.get(link)
-    .on('response', function error(res) {
-      if (res.statusCode !== 200) {
-        this.emit('error', { message: 'Could not read file', path: link });
-      }
-    });
+  const trimStream = new TrimStream();
+  const remoteStream = request.get(link);
+
+  remoteStream.on('response', function error(res) {
+    if (res.statusCode !== 200) {
+      this.emit('error', { message: 'Could not read file', path: link });
+    }
+  });
+
+  remoteStream.pipe(trimStream);
+
+  return duplexer({ objectMode: true }, remoteStream, trimStream);
 }

--- a/src/inflaters/local.js
+++ b/src/inflaters/local.js
@@ -1,5 +1,18 @@
 import fs from 'fs';
+import duplexer from 'duplexer2';
+import TrimStream from '../trim-stream';
 
+/**
+ * Local link inflater
+ *
+ * Simply returns readable stream of the file with trailing new line removed.
+ * This allows inline transclusion by stripping traiing new line at EOF.
+ */
 export default function inflate(link) {
-  return fs.createReadStream(link, { encoding: 'utf8' });
+  const trimStream = new TrimStream();
+  const localStream = fs.createReadStream(link, { encoding: 'utf8' });
+
+  localStream.pipe(trimStream);
+
+  return duplexer({ objectMode: true }, localStream, trimStream);
 }

--- a/src/resolve-stream.js
+++ b/src/resolve-stream.js
@@ -4,8 +4,6 @@ import duplexer from 'duplexer2';
 import regexpTokenizer from 'regexp-stream-tokenizer';
 
 import { parseTransclude, resolveReferences, resolveLink } from './resolve';
-import TrimStream from './trim-stream';
-
 import { defaultTokenRegExp, defaultToken, defaultSeparator, WHITESPACE_GROUP } from './config';
 
 /**
@@ -26,7 +24,6 @@ export default function ResolveStream(source, opt) {
 
   function inflate(link, relativePath, references, parents, indent) {
     const resolverStream = new ResolveStream(link);
-    const trimmerStream = new TrimStream();
 
     function token(match) {
       return _.merge(
@@ -47,9 +44,9 @@ export default function ResolveStream(source, opt) {
     const linkRegExp = _.get(options, 'linkRegExp') || defaultTokenRegExp;
     const tokenizerStream = regexpTokenizer(tokenizerOptions, linkRegExp);
 
-    trimmerStream.pipe(tokenizerStream).pipe(resolverStream);
+    tokenizerStream.pipe(resolverStream);
 
-    return duplexer({ objectMode: true }, trimmerStream, resolverStream);
+    return duplexer({ objectMode: true }, tokenizerStream, resolverStream);
   }
 
   /* eslint-disable consistent-return */

--- a/src/trim-stream.js
+++ b/src/trim-stream.js
@@ -1,5 +1,4 @@
 import through2 from 'through2';
-import _ from 'lodash';
 
 /**
 * Trims new line at EOF to allow a file to be transcluded inline.
@@ -15,11 +14,6 @@ export default function TrimStream() {
   let inputBuffer = '';
 
   function transform(chunk, encoding, cb) {
-    // Allow objects to be passed through unaltered
-    if (!_.isString(chunk) && !_.isBuffer(chunk)) {
-      return cb(null, chunk);
-    }
-
     const input = chunk.toString('utf8');
 
     // Combine buffer and new input

--- a/test/units/inflaters/http.js
+++ b/test/units/inflaters/http.js
@@ -1,0 +1,39 @@
+import test from 'ava';
+import nock from 'nock';
+import concat from 'concat-stream';
+global.fs = require('fs');
+
+import httpInflater from '../../../src/inflaters/http';
+
+test.before(() => {
+  nock('http://github.com').get('/foo.md').reply(200, 'foo\nbar\n');
+  nock('http://github.com').get('/i-dont-exist.md').reply(404);
+});
+
+test.cb('should return stream with contents of the file without trailing new line', (t) => {
+  const link = 'http://github.com/foo.md';
+  const testStream = httpInflater(link);
+
+  t.plan(1);
+
+  const concatStream = concat((result) => {
+    t.deepEqual(result.toString('utf8'), 'foo\nbar');
+    t.end();
+  });
+
+  testStream.pipe(concatStream);
+});
+
+test.cb('should emit error if file not found', (t) => {
+  const link = 'http://github.com/i-don-exist.md';
+  const testStream = httpInflater(link);
+
+  t.plan(1);
+
+  testStream.on('error', (err) => {
+    t.truthy(err);
+    t.end();
+  });
+
+  testStream.read();
+});

--- a/test/units/resolve-stream.js
+++ b/test/units/resolve-stream.js
@@ -5,6 +5,7 @@ global.fs = require('fs');
 
 import ResolveStream from '../../src/resolve-stream';
 
+// TODO: directly mock inflate logic
 test.before(() => {
   const foxStream = new Readable;
   foxStream.push('fox');

--- a/test/units/trim-stream.js
+++ b/test/units/trim-stream.js
@@ -18,24 +18,6 @@ test.cb('should handle no input', (t) => {
 });
 
 
-test.cb('should not modify object chunks', (t) => {
-  const input = { content: 'The quick brown fox jumps over the lazy dog.' };
-  const testStream = new TrimStream();
-
-  testStream.on('readable', function read() {
-    let chunk = null;
-    while ((chunk = this.read()) !== null) {
-      t.deepEqual(chunk, input);
-    }
-  });
-
-  testStream.on('end', () => t.end());
-
-  testStream.write(input);
-  testStream.end();
-});
-
-
 test.cb('should not modify input without trailing new line', (t) => {
   const input = 'The quick brown fox jumps over the lazy dog.';
   const testStream = new TrimStream();


### PR DESCRIPTION
Improves isolation of logic associated with transcluding files in contrast with strings.

TODO: add tests for HTTP and Local inflaters