### PR TITLE
Fix: Made pegjs a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "dashdash": "^1.10.1",
     "duplexer2": "^0.1.4",
     "lodash": "^4.0.0",
+    "pegjs": "^0.9.0",
     "regexp-stream-tokenizer": "^0.2.0",
     "request": "^2.65.0",
     "through2": "^2.0.0",
@@ -82,7 +83,6 @@
     "istanbul": "^0.4.1",
     "nock": "^8.0.0",
     "nyc": "^6.0.0",
-    "pegjs": "^0.9.0",
     "semver": "^5.1.0",
     "shelljs": "^0.6.0",
     "sinon": "^1.17.3"


### PR DESCRIPTION
This moves pegjs from dev-dependencies to dependencies.

## Problem

Version 3.0.3 added pegjs as a dependency in e94b36803a but pegjs is still listed as a dev-dependency. This PR moves pegjs to dependencies.

### Error

    $ hercule "src/index.md" --output "build/docs.md"
    module.js:442
        throw err;
        ^
    
    Error: Cannot find module 'pegjs'
        at Function.Module._resolveFilename (module.js:440:15)
        at Function.Module._load (module.js:388:25)
        at Module.require (module.js:468:17)
        at require (internal/module.js:20:19)
        at Object.<anonymous> (api/node_modules/hercule/lib/grammar/index.js:11:14)
        at Module._compile (module.js:541:32)
        at Object.Module._extensions..js (module.js:550:10)
        at Module.load (module.js:458:32)
        at tryModuleLoad (module.js:417:12)
        at Function.Module._load (module.js:409:3)