### PR TITLE
Fix: indentation regression

### DIFF
--- a/test/fixtures/indentation/_expect.md
+++ b/test/fixtures/indentation/_expect.md
@@ -5,5 +5,3 @@ BY LEWIS CARROLL
           Did gyre and gimble in the wabe:
     All mimsy were the borogoves,
           And the mome raths outgrabe.
-    
-The End.

--- a/test/fixtures/indentation/_expect.md.map
+++ b/test/fixtures/indentation/_expect.md.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["index.md","verse1.md"],"names":[],"mappings":"AAAA;AACA;AACA;AACA,ICHA;IACA;IACA;IACA;IDCA;AACA","file":"../test/fixtures/indentation/_expect.md"}
+{"version":3,"sources":["index.md","verse1.md"],"names":[],"mappings":"AAAA;AACA;AACA;AACA,ICHA;IACA;IACA;IACA","file":"../test/fixtures/indentation/_expect.md"}

--- a/test/fixtures/indentation/index.md
+++ b/test/fixtures/indentation/index.md
@@ -2,5 +2,3 @@ Jabberwocky
 BY LEWIS CARROLL
 
     :[Verse One](verse1.md)
-
-The End.


### PR DESCRIPTION
Indentation (whitespace) should never be inserted between two new lines (`\n\n`) nor on the final line of output (`\n___`).

Closes #334 