### PR TITLE
Update gulp example

### DIFF
--- a/examples/gulp/gulpfile.js
+++ b/examples/gulp/gulpfile.js
@@ -10,14 +10,17 @@ gulp.task('hercule', function() {
       }
 
       if (file.isBuffer()) {
-        hercule.transcludeString(file.contents.toString(encoding), options, function(output) {
+        hercule.transcludeString(file.contents.toString(encoding), options, function(err, output) {
+          if (err) {
+            return callback(err, null)
+          }
           file.contents = new Buffer(output);
           return callback(null, file);
         })
       }
 
       if (file.isStream()) {
-        var transcluder = new hercule.TranscludeStream(null, options);
+        var transcluder = new hercule.TranscludeStream(options);
         file.contents = file.contents.pipe(transcluder);
         return callback(null, file);
       }


### PR DESCRIPTION
The `hercule.transcludeString` and `hercule.TranscludeStream` functions were throwing errors when running the basic gulp example, but after updating their signatures everything worked great.