### PR TITLE
Add placeholder arg to resolver API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add `placeholder` argument to resolver API allowing resolver functions to pass the unmodified content back and skip the link. This allows the default behaviour where unresolvable links throw an error to be overridden with a best-effort approach.
+
 ## [4.0.1] - 2017-05-27
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ __Arguments__
 
 1. `url` - A relative url from the input being processed.
 2. `source` - The absolute source url of the url being resolved.
+3. `placeholder` - The transclusion link that was resolved to the url.
 
 __Returns__
 
@@ -308,7 +309,7 @@ __Examples__
 ```javascript
 import { trancludeFile, resolveHttpUrl, resolveLocalUrl, resolveString } from 'hercule';
 
-function myResolver(url, source) {
+function myResolver(url, source, placeholder) {
   // Add your implementation here
   // Return null to try next resolver
   return null;

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -46,10 +46,14 @@ const defaultResolvers = [resolveHttpUrl, resolveLocalUrl, resolveString];
 //  - resolvers is an array of synchronus functions that return null, string or stream.
 //  - stream requires processing
 //  - string assumed fully processed
-export function resolveToReadableStream(link, resolvers = defaultResolvers) {
+export function resolveToReadableStream(
+  link,
+  resolvers = defaultResolvers,
+  placeholder
+) {
   const { content, url } = _.reduce(
     resolvers,
-    (memo, resolver) => memo || resolver(link.url, link.source),
+    (memo, resolver) => memo || resolver(link.url, link.source, placeholder),
     null
   );
 

--- a/src/transclude.js
+++ b/src/transclude.js
@@ -119,7 +119,8 @@ export default function Transclude(source = 'string', options = {}) {
 
       const { contentStream, resolvedUrl } = resolveToReadableStream(
         link,
-        resolvers
+        resolvers,
+        content
       );
       if (_.includes(parents, resolvedUrl)) {
         self.push(link);

--- a/test/units/resolver.js
+++ b/test/units/resolver.js
@@ -39,6 +39,18 @@ test('handles url resolved to stream', t => {
   t.truthy(isStream(contentStream));
 });
 
+test('calls resolvers with placeholder', t => {
+  const resolvers = [(url, source, placeholder) => ({ content: placeholder })];
+  const { contentStream, resolvedUrl } = resolver.resolveToReadableStream(
+    { url: '"foo.md"', source: 'bar.md' },
+    resolvers,
+    ':[](foo.md)'
+  );
+
+  t.falsy(resolvedUrl);
+  t.truthy(isStream(contentStream));
+});
+
 test('throws if not resolved', t => {
   const resolvers = [() => _.constant(null)];
   const error = t.throws(() =>


### PR DESCRIPTION
The placeholder argument allows resolvers that pass the entire link straight through rather than consuming it.

Closes #386 
Closes #389 