### PR TITLE
Add official Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM mhart/alpine-node
+
+RUN npm install -g hercule@latest
+
+CMD ["hercule"]


### PR DESCRIPTION
It'd be great if this tool was available as a Docker container.  Depending on the npm release process, `@latest` may not be the best route.  DockerHub builds can be configured to initiate a build whenever a new `tag` or release is added to the repo.