### PR TITLE
fix(cli): Remove mention of - as a shorthand for --stdin

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const cli = meow(
     '  $ hercule [<input> ...]',
     '',
     'Options:',
-    '  --stdin, -                 Specifies input to be read from stdin.',
+    '  --stdin                    Specifies input to be read from stdin.',
     '  --output, -o path          Specifies the name and location of the output file.  If not specified, stdout is used.',
     '  --syntax, -s syntax_name   Specifies which transclusion link syntax (e.g. hercule, aglio, marked, multimarkdown).',
     '                             If not specifed, hercule is used.',


### PR DESCRIPTION
I discovered it doesn't actually work while trying to update meow to version 4.

To confirm add the following test case to `test/bats`:

```
@test "accepts input from stdin using shorthand" {
  run bash -c "cat ./test/fixtures/local-link/index.md | ./bin/hercule - --relative ./test/fixtures/local-link"
  [ "$status" -eq 0 ]
  [ "$output" == "Jackdaws love my big sphinx of quartz." ]
}
```