### PR TITLE
Add a promise based API available as "hercule/promises"

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ deposit in :[](CODE || "GBP").</pre>
 - [`transcludeFile`](#transcludeFile)
 - [Resolvers](#resolvers)
 - [Custom Transclusion Syntax](#customSyntax)
+- [Promises](#promises)
 
 ---------------------------------------
 
@@ -338,4 +339,29 @@ transcludeFile('foo.md', { resolvers }, (err, output) => {
   if (err) console.log(err)
   console.log(output);
 });
+```
+
+---------------------------------------
+
+<a name="promises" />
+
+### Promises
+
+A promise interface for `transcludeString` and `transcludeFile` is available
+when requiring `hercule/promises`.
+
+```javascript
+import { transcludeString } from 'hercule/promises';
+
+transcludeString(':[foo](bar.md)')
+.then(({output}) => console.log(output))
+.catch(err => console.log(err));
+```
+
+```javascript
+import { transcludeFile } from 'hercule/promises';
+
+transcludeFile('foo.md')
+.then(({output}) => console.log(output))
+.catch(err => console.log(err));
 ```

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "hercule",
   "version": "5.0.1",
   "description": "Markdown, API Blueprint and string transclusion",
-  "main": "./lib/hercule",
+  "main": "./lib/hercule.js",
+  "exports": {
+    ".": "./lib/hercule.js",
+    "./promises": "./lib/promises.js",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "test": "npm run test-units && npm run test-integration && npm run test-cli",
     "test-units": "nyc --cache ava --verbose test/units/**/*.js",

--- a/promises.js
+++ b/promises.js
@@ -1,0 +1,4 @@
+// This file is a temporary solution to support require('hercule/promises')
+// until all supported Node.js version support "exports" (12.7+)
+
+module.exports = require('./lib/promises.js');

--- a/src/promises.js
+++ b/src/promises.js
@@ -1,0 +1,39 @@
+import {
+  transcludeString as transcludeStringCb,
+  transcludeFile as transcludeFileCb,
+} from './hercule';
+
+export {
+  TranscludeStream,
+  resolveHttpUrl,
+  resolveLocalUrl,
+  resolveString,
+} from './hercule';
+
+export async function transcludeString(input, options = {}) {
+  return new Promise((resolve, reject) => {
+    transcludeStringCb(input, options, (err, output, sourceMap) => {
+      if (err) {
+        // eslint-disable-next-line no-param-reassign
+        err.sourceMap = sourceMap;
+        reject(err);
+      }
+
+      resolve({ output, sourceMap });
+    });
+  });
+}
+
+export async function transcludeFile(input, options = {}) {
+  return new Promise((resolve, reject) => {
+    transcludeFileCb(input, options, (err, output, sourceMap) => {
+      if (err) {
+        // eslint-disable-next-line no-param-reassign
+        err.sourceMap = sourceMap;
+        reject(err);
+      }
+
+      resolve({ output, sourceMap });
+    });
+  });
+}

--- a/test/units/transcludeFilePromises.js
+++ b/test/units/transcludeFilePromises.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import path from 'path';
+
+import { transcludeFile } from '../../src/promises';
+
+test('should transclude with only required arguments', async t => {
+  const input = path.join(__dirname, '../fixtures/no-link/index.md');
+  const expected = 'The quick brown fox jumps over the lazy dog.\n';
+
+  const { output } = await transcludeFile(input);
+  t.deepEqual(output, expected);
+});
+
+test('should transclude with optional relativePath argument', async t => {
+  const input = path.join(__dirname, '../fixtures/no-link/index.md');
+  const expected = 'The quick brown fox jumps over the lazy dog.\n';
+
+  const { output } = await transcludeFile(input, { relativePath: 'test' });
+  t.deepEqual(output, expected);
+});
+
+test("should return error if file doesn't exist", async t => {
+  const input = path.join('i-dont-exist.md');
+
+  try {
+    await transcludeFile(input);
+  } catch (err) {
+    t.regex(err.message, /ENOENT/);
+    t.is(err.path, 'i-dont-exist.md');
+  }
+});
+
+test('should return sourceList', async t => {
+  const input = path.join(__dirname, '../fixtures/local-link/index.md');
+  const expected = 'Jackdaws love my big sphinx of quartz.\n';
+
+  const { output, sourceMap } = await transcludeFile(input);
+  t.deepEqual(output, expected);
+  t.regex(sourceMap.sources[1], /size\.md/);
+  t.is(sourceMap.sources.length, 2);
+});

--- a/test/units/transcludeStringPromises.js
+++ b/test/units/transcludeStringPromises.js
@@ -1,0 +1,47 @@
+import test from 'ava';
+import path from 'path';
+
+import { transcludeString } from '../../src/promises';
+
+test('should transclude with only required arguments', async t => {
+  const input = 'The quick brown fox jumps over the lazy dog.';
+  const expected = 'The quick brown fox jumps over the lazy dog.';
+
+  const { output } = await transcludeString(input);
+  t.deepEqual(output, expected);
+});
+
+test('should transclude with optional source argument', async t => {
+  const input = 'The quick brown fox jumps over the lazy dog.';
+  const expected = 'The quick brown fox jumps over the lazy dog.';
+
+  const { output } = await transcludeString(input, { source: 'test' });
+  t.deepEqual(output, expected);
+});
+
+test('returns sourcemap', async t => {
+  const input = 'Jackdaws love my :[size link](size.md) sphinx of quartz.';
+  const options = {
+    source: path.join(__dirname, '../fixtures/local-link/index.md'),
+  };
+  const expected = 'Jackdaws love my big sphinx of quartz.';
+
+  const { output, sourceMap } = await transcludeString(input, options);
+  t.deepEqual(output, expected);
+  t.is(sourceMap.sources.length, 2);
+});
+
+test('returns error for invalid links', async t => {
+  const input =
+    'Jackdaws love my :[missing](i-dont-exist.md) sphinx of :[missing](mineral.md)';
+  const options = {
+    source: path.join(__dirname, '../fixtures/invalid-link/index.md'),
+  };
+
+  try {
+    await transcludeString(input, options);
+  } catch (err) {
+    t.regex(err.message, /ENOENT/);
+    t.regex(err.path, /fixtures\/invalid-link\/i-dont-exist.md/);
+  }
+});


### PR DESCRIPTION
Fixes #442

This is especially valuable for Hercule because a standard `promisify` loses access to the source map.

This matches the pattern that Node.js is adopting (e.g. `fs/promises`) and gives a clean separation between the promise based and the callback interface. If you ever want to change the default you could introduce `hercule/callback` and the migration strategy would be to simply change the import.

Note that the use of `exports` will prevent deep-requiring anything files shipped in the package. For example `require('hercule/lib/parse.js')` would no longer work. This could be considered a breaking change. I did add `package.json` to the list of exported files as some tools require access to it (see https://github.com/nodejs/node/issues/33460).