### PR TITLE
Reduce reliance on lodash methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "arrow-parens": [2, "as-needed"],
     "id-length": [2, {"min": 2, "max": 25, "properties": "never", "exceptions": ["_"]}],
     "no-cond-assign": [2, "except-parens"],
-    "lodash/import-scope": [2, "full"],
+    "lodash/prefer-lodash-method": "off",
     "prettier/prettier": [2, {"singleQuote": true, "trailingComma": "es5"}]
   }
 }

--- a/src/hercule.js
+++ b/src/hercule.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import _ from 'lodash';
 import duplexer from 'duplexer3';
 import get from 'through2-get';
 import getStream from 'get-stream';
@@ -11,8 +10,8 @@ import Sourcemap from './sourcemap';
 
 export { resolveHttpUrl, resolveLocalUrl, resolveString } from './resolver';
 
-export function TranscludeStream(source = 'input', options) {
-  const outputFile = _.get(options, 'outputFile');
+export function TranscludeStream(source = 'input', options = {}) {
+  const { outputFile } = options;
   let sourceMap;
 
   const transclude = new Transclude(source, options);
@@ -37,7 +36,7 @@ export function TranscludeStream(source = 'input', options) {
 export function transcludeString(input, ...args) {
   const cb = args.pop();
   const [options = {}] = args;
-  const source = _.get(options, 'source') || 'string';
+  const source = options.source || 'string';
 
   const transclude = new TranscludeStream(source, options);
   let sourceMap;

--- a/src/indent.js
+++ b/src/indent.js
@@ -1,5 +1,4 @@
 import through2 from 'through2';
-import _ from 'lodash';
 
 export default function Indent() {
   const NEWLINE = '\n';
@@ -18,7 +17,7 @@ export default function Indent() {
       if (indent) {
         if (preceededNewLine && !beginsNewLine) content = indent + content;
 
-        content = _.replace(content, /\n(?!\s|$)/g, `\n${indent}`);
+        content = content.replace(/\n(?!\s|$)/g, `\n${indent}`);
         inputBuffer[1].content = content;
       }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import grammar from '../grammars/link';
 
 function extendWithSource(link, source, line, column) {
@@ -12,10 +11,10 @@ export function parseContent(content, { source, line, column }) {
 
   // Attach source information to all the url to be resolved
   const contentLink = extendWithSource(args.link, source, line, column);
-  const scopeReferences = _.map(args.scopeReferences, ref =>
+  const scopeReferences = args.scopeReferences.map(ref =>
     extendWithSource(ref, source, line, column)
   );
-  const descendantReferences = _.map(args.descendantReferences, ref =>
+  const descendantReferences = args.descendantReferences.map(ref =>
     extendWithSource(ref, source, line, column)
   );
 

--- a/src/resolver.js
+++ b/src/resolver.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import isString from 'lodash/isString';
 import fs from 'fs';
 import path from 'path';
 import got from 'got';
@@ -51,15 +51,14 @@ export function resolveToReadableStream(
   resolvers = defaultResolvers,
   placeholder
 ) {
-  const { content, url } = _.reduce(
-    resolvers,
+  const { content, url } = resolvers.reduce(
     (memo, resolver) => memo || resolver(link.url, link.source, placeholder),
     null
   );
 
   let outputStream;
 
-  if (_.isString(content)) {
+  if (isString(content)) {
     outputStream = through2({ objectMode: true });
 
     outputStream.push({

--- a/src/sourcemap.js
+++ b/src/sourcemap.js
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import _ from 'lodash';
 import through2 from 'through2';
 import sourceMap from 'source-map';
 
@@ -48,7 +47,7 @@ export default function SourceMapStream(generatedFile = 'string') {
     const generator = new sourceMap.SourceMapGenerator({
       file: path.relative(__dirname, generatedFile),
     });
-    _.forEach(mappings, map => generator.addMapping(map));
+    mappings.forEach(map => generator.addMapping(map));
     this.emit('sourcemap', JSON.parse(generator.toString()));
     return cb();
   }

--- a/src/trim.js
+++ b/src/trim.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import through2 from 'through2';
 
 export default function Trim() {
@@ -15,7 +14,7 @@ export default function Trim() {
     while (inputBuffer.length > 1) {
       const nextFileIsAncestor =
         inputBuffer[1].parents &&
-        _.includes(inputBuffer[0].parents, inputBuffer[1].source);
+        (inputBuffer[0].parents || []).includes(inputBuffer[1].source);
       const isFileEdge =
         inputBuffer[0].source !== inputBuffer[1].source &&
         memoSource !== inputBuffer[1].source;

--- a/test/integration/transcludeFile.js
+++ b/test/integration/transcludeFile.js
@@ -1,12 +1,11 @@
 import test from 'ava';
-import _ from 'lodash';
 
 import { transcludeFile } from '../../src/hercule';
 // eslint-disable-next-line ava/no-import-test-files
 import fixtures from '../fixtures';
 import './_mock';
 
-_.forEach(fixtures.fixtures, fixture => {
+fixtures.fixtures.forEach(fixture => {
   test.cb(`should transclude ${fixture.name}`, t => {
     const config = fixture.expectedConfig;
     const options = config.options || {};

--- a/test/integration/transcludeStream.js
+++ b/test/integration/transcludeStream.js
@@ -1,5 +1,4 @@
 import test from 'ava';
-import _ from 'lodash';
 import fs from 'fs';
 
 import { TranscludeStream } from '../../src/hercule';
@@ -7,7 +6,7 @@ import { TranscludeStream } from '../../src/hercule';
 import fixtures from '../fixtures';
 import './_mock';
 
-_.forEach(fixtures.fixtures, fixture => {
+fixtures.fixtures.forEach(fixture => {
   test.cb(`should transclude ${fixture.name}`, t => {
     const config = fixture.expectedConfig;
     const options = config.options || {};

--- a/test/integration/transcludeString.js
+++ b/test/integration/transcludeString.js
@@ -1,12 +1,11 @@
 import test from 'ava';
-import _ from 'lodash';
 
 import { transcludeString } from '../../src/hercule';
 // eslint-disable-next-line ava/no-import-test-files
 import fixtures from '../fixtures';
 import './_mock';
 
-_.forEach(fixtures.fixtures, fixture => {
+fixtures.fixtures.forEach(fixture => {
   test.cb(`should transclude ${fixture.name}`, t => {
     const config = fixture.expectedConfig;
     const options = config.options || {};

--- a/test/units/resolver.js
+++ b/test/units/resolver.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import sinon from 'sinon';
-import _ from 'lodash';
+import isString from 'lodash/isString';
+import constant from 'lodash/constant';
 import { Readable } from 'stream';
 import isStream from 'isstream';
 import nock from 'nock';
@@ -53,7 +54,7 @@ test('calls resolvers with placeholder', t => {
 });
 
 test('throws if not resolved', t => {
-  const resolvers = [() => _.constant(null)];
+  const resolvers = [() => constant(null)];
   const error = t.throws(() =>
     resolver.resolveToReadableStream({ url: 'foo' }, resolvers)
   );
@@ -86,7 +87,7 @@ test('returns falsy if not local url', t => {
 
 test('returns string if quoted input', t => {
   const { content } = resolver.resolveString('"foo! bar!"');
-  t.truthy(_.isString(content));
+  t.truthy(isString(content));
 });
 
 test('returns falsy if unquoted input', t => {


### PR DESCRIPTION
Aligning with https://github.com/jamesramsay/through2-get/pull/118 this PR does two things

- Use the per-method imports for lodash 
- Make use of native Node.js functionality when that's easily possible

Use Node.js 14.15.1 the benchmark results show no performance impact or even a tiny improvement:

main:
```
> ./test/benchmark.js

hercule#transcludeFile x 1,284 ops/sec ±6.85% (71 runs sampled)
hercule#TranscludeStream x 1,525 ops/sec ±0.79% (82 runs sampled)
hercule#transcludeString x 1,616 ops/sec ±0.68% (85 runs sampled)
```

This branch:
```
> ./test/benchmark.js

hercule#transcludeFile x 1,309 ops/sec ±8.13% (71 runs sampled)
hercule#TranscludeStream x 1,543 ops/sec ±0.93% (79 runs sampled)
hercule#transcludeString x 1,639 ops/sec ±1.25% (82 runs sampled)
```

Outside of tests the following lodash functions are still used:

- `isString`
- `uniqBy`
- `isPlainObject`