### PR TITLE
Fix: package did not include all required files

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "files": [
     "bin",
     "lib/*.js",
-    "grammars/links.js",
+    "promise.js",
+    "grammars/link.js",
     "PURPOSE.md"
   ],
   "ava": {


### PR DESCRIPTION
There are two missing files in 5.1:

1. `grammar/link.js`
2. `promises.js`

1. is because I made a typo in #599 (🤦). 2. is because #603 was created before #599 was merged so it couldn't add the new file to the list.

Sorry for the extra pain.